### PR TITLE
make regex for tokenizer work in python3

### DIFF
--- a/eywa/lang/en/model.py
+++ b/eywa/lang/en/model.py
@@ -38,7 +38,7 @@ tokens_db = Database(tokens_db_file_name, key_type=str, value_type=list)
 
 
 def tokenizer(X):
-    return [x.strip() for x in re.split('(\W+)?', X) if x.strip()]
+    return [x.strip() for x in re.split('(\W+)', X) if x.strip()]
 
 
 caps = "([A-Z])"


### PR DESCRIPTION
Previous one was giving different result in python3 for the split

In python3:

```
re.split("(\W+)?", "hello there")
['', None, 'h', None, 'e', None, 'l', None, 'l', None, 'o', ' ', '', None, 't', None, 'h', None, 'e', None, 'r', None, 'e', None, '']
```