### PR TITLE
Token.in_vocab bug fix

### DIFF
--- a/eywa/lang/en/model.py
+++ b/eywa/lang/en/model.py
@@ -323,7 +323,7 @@ class Token(object):
         try:
             return self._in_vocab
         except AttributeError:
-            _in_vocab = any(self.embedding)
+            _in_vocab = tf.math.count_nonzero(self.embedding).numpy() != 0
             self._in_vocab = _in_vocab
             return _in_vocab
 


### PR DESCRIPTION
>>> from eywa.lang import Token
>>> a = "hey"
>>> a = Token(a)
>>> a.in_vocab
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/purackal/projects/hobby/eywa/eywa/lang/en/model.py", line 326, in in_vocab
    _in_vocab = any(self.embedding)
  File "/home/purackal/virutalenvs/eywa/lib/python3.6/site-packages/tensorflow/python/ops/variables.py", line 968, in __iter__
    raise TypeError("'Variable' object is not iterable.")
TypeError: 'Variable' object is not iterable.
