### PR TITLE
bug fix for entity extractor

### DIFF
--- a/eywa/nlu/entity_extractor.py
+++ b/eywa/nlu/entity_extractor.py
@@ -43,8 +43,8 @@ class EntityExtractor(object):
         keys = self.keys
         for i, (x, y) in enumerate(zip(self.X, self.Y)):
             for k in keys:
-                if k in y:
-                    kk = keys[k]
+                kk = keys[k]
+                if k in y:                    
                     types = kk['types']
                     v = y[k]
                     indices = []


### PR DESCRIPTION
The indices for train data with key not specified in Y were being added to the wrong key due to declaration being inside.